### PR TITLE
Change/add methods to have true consistency with similar array methods

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -318,6 +318,11 @@ class Collection extends Map {
         }
         accumulator = fn(accumulator, val, key, this);
       }
+
+      // No item iterated.
+      if (first) {
+        throw new TypeError('Reduce of empty collection with no initial value');
+      }
     }
     return accumulator;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -396,10 +396,15 @@ class Collection extends Map {
     if (!collection) return false;
     if (this === collection) return true;
     if (this.size !== collection.size) return false;
-    return !this.find((value, key) => {
-      const testVal = collection.get(key);
-      return testVal !== value || (testVal === undefined && !collection.has(key));
-    });
+    for (const [key, value] of this) {
+      if (!collection.has(key)) {
+        return false;
+      }
+      if (value !== collection.get(key)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -412,10 +412,7 @@ class Collection extends Map {
     if (this === collection) return true;
     if (this.size !== collection.size) return false;
     for (const [key, value] of this) {
-      if (!collection.has(key)) {
-        return false;
-      }
-      if (value !== collection.get(key)) {
+      if (!collection.has(key) || value !== collection.get(key)) {
         return false;
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -407,8 +407,13 @@ class Collection extends Map {
    * @example collection.sort((userA, userB) => userA.createdTimestamp - userB.createdTimestamp);
    */
   sort(compareFunction = (x, y) => +(x > y) || +(x === y) - 1) {
-    return new this.constructor[Symbol.species]([...this.entries()]
-      .sort((a, b) => compareFunction(a[1], b[1], a[0], b[0])));
+    const entries = [...this.entries()];
+    entries.sort((a, b) => compareFunction(a[1], b[1], a[0], b[0]));
+    this.clear();
+    for (const [k, v] of entries) {
+      this.set(k, v);
+    }
+    return this;
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -334,7 +334,7 @@ class Collection extends Map {
         accumulator = fn(accumulator, val, key, this);
       }
 
-      // No item iterated.
+      // No items iterated.
       if (first) {
         throw new TypeError('Reduce of empty collection with no initial value');
       }

--- a/src/index.js
+++ b/src/index.js
@@ -247,7 +247,7 @@ class Collection extends Map {
   }
 
   /**
-   * Maps each item to another value. Identical in behavior to
+   * Maps each item to another value into an array. Identical in behavior to
    * [Array.map()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map).
    * @param {Function} fn Function that produces an element of the new array, taking three arguments
    * @param {*} [thisArg] Value to use as `this` when executing function
@@ -260,6 +260,21 @@ class Collection extends Map {
     let i = 0;
     for (const [key, val] of this) arr[i++] = fn(val, key, this);
     return arr;
+  }
+
+  /**
+   * Maps each item to another value into a collection. Identical in behavior to
+   * [Array.map()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map).
+   * @param {Function} fn Function that produces an element of the new collection, taking three arguments
+   * @param {*} [thisArg] Value to use as `this` when executing function
+   * @returns {Array}
+   * @example collection.mapValues(user => user.tag);
+   */
+  mapValues(fn, thisArg) {
+    if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
+    const coll = new this.constructor[Symbol.species]();
+    for (const [key, val] of this) coll.set(key, fn(val, key, this));
+    return coll;
   }
 
   /**

--- a/test/index.js
+++ b/test/index.js
@@ -170,6 +170,11 @@ test('reduce collection into a single value without initial value', () => {
   assert.strictEqual(sum, 6);
 });
 
+test('reduce empty collection without initial value', () => {
+  const coll = new Collection();
+  assert.throws(() => coll.reduce((a, x) => a + x), /^TypeError: Reduce of empty collection with no initial value$/);
+});
+
 test('iterate over each item', () => {
   const coll = new Collection();
   coll.set('a', 1);

--- a/test/index.js
+++ b/test/index.js
@@ -136,6 +136,15 @@ test('map items in a collection into an array', () => {
   assert.deepStrictEqual(mapped, [2, 3, 4]);
 });
 
+test('map items in a collection into a collection', () => {
+  const coll = new Collection();
+  coll.set('a', 1);
+  coll.set('b', 2);
+  coll.set('c', 3);
+  const mapped = coll.mapValues(x => x + 1);
+  assert.deepStrictEqual(mapped.array(), [2, 3, 4]);
+});
+
 test('check if some items pass a predicate', () => {
   const coll = new Collection();
   coll.set('a', 1);

--- a/test/index.js
+++ b/test/index.js
@@ -221,12 +221,12 @@ test('check equality of two collections', () => {
   assert.ok(!coll1.equals(coll2));
 });
 
-test('sort a collection', () => {
+test('sort a collection in place', () => {
   const coll = new Collection();
   coll.set('a', 3);
   coll.set('b', 2);
   coll.set('c', 1);
   assert.deepStrictEqual(coll.array(), [3, 2, 1]);
-  const sorted = coll.sort((a, b) => a - b);
-  assert.deepStrictEqual(sorted.array(), [1, 2, 3]);
+  coll.sort((a, b) => a - b);
+  assert.deepStrictEqual(coll.array(), [1, 2, 3]);
 });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -21,6 +21,7 @@ declare class Collection<K, V> extends Map<K, V> {
 	public lastKey(): K | undefined;
 	public lastKey(count: number): K[];
 	public map<T>(fn: (value: V, key: K, collection: Collection<K, V>) => T, thisArg?: any): T[];
+	public mapValues<T>(fn: (value: V, key: K, collection: Collection<K, V>) => T, thisArg?: any): Collection<K, T>;
 	public partition(fn: (value: V, key: K, collection: Collection<K, V>) => boolean): [Collection<K, V>, Collection<K, V>];
 	public random(): V | undefined;
 	public random(count: number): V[];


### PR DESCRIPTION
- `Collection#sort` now does it in place just as `Array#sort` does. This will require some changes in Discord.js but also makes the clone more explicit.
- `Collection#reduce` now correctly throws when there is no elements and no initial value.
- Add `Collection#mapValues`. The idea is that we can do `Array<A> → Array<B>` but not `Collection<K, A> → Collection<K, B>` trivially. The initial solution was to change `Collection#map` but the breaking of code was an issue so this new method is the compromise.
- Fixed `Collection#equals` to handle an edge case.