### PR TITLE
added flatMap method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -263,6 +263,19 @@ class Collection extends Map {
   }
 
   /**
+   * Maps each item into a Collection, then joins the results into a single Collection. Identical in behavior to
+   * [Array.flatMap()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap).
+   * @param {Function} fn Function that produces a new Collection
+   * @param {*} [thisArg] Value to use as `this` when executing function
+   * @returns {Collection}
+   * @example collection.flatMap(guild => guild.users);
+   */
+  flatMap(fn, thisArg) {
+    const collections = this.map(fn, thisArg);
+    return new this.constructor[Symbol.species]().concat(...collections);
+  }
+
+  /**
    * Maps each item to another value into a collection. Identical in behavior to
    * [Array.map()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map).
    * @param {Function} fn Function that produces an element of the new collection, taking three arguments

--- a/src/index.js
+++ b/src/index.js
@@ -268,7 +268,7 @@ class Collection extends Map {
    * @param {Function} fn Function that produces a new Collection
    * @param {*} [thisArg] Value to use as `this` when executing function
    * @returns {Collection}
-   * @example collection.flatMap(guild => guild.users);
+   * @example collection.flatMap(guild => guild.members);
    */
   flatMap(fn, thisArg) {
     const collections = this.map(fn, thisArg);

--- a/test/index.js
+++ b/test/index.js
@@ -145,6 +145,20 @@ test('map items in a collection into a collection', () => {
   assert.deepStrictEqual(mapped.array(), [2, 3, 4]);
 });
 
+test('flatMap items in a collection into a single collection', () => {
+  const coll = new Collection();
+  const coll1 = new Collection();
+  const coll2 = new Collection();
+  coll1.set('z', 1);
+  coll1.set('x', 2);
+  coll2.set('c', 3);
+  coll2.set('v', 4);
+  coll.set('a', { a: coll1 });
+  coll.set('b', { a: coll2 });
+  const mapped = coll.flatMap(x => x.a);
+  assert.deepStrictEqual(mapped.array(), [1, 2, 3, 4]);
+});
+
 test('check if some items pass a predicate', () => {
   const coll = new Collection();
   coll.set('a', 1);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -21,6 +21,7 @@ declare class Collection<K, V> extends Map<K, V> {
 	public lastKey(): K | undefined;
 	public lastKey(count: number): K[];
 	public map<T>(fn: (value: V, key: K, collection: Collection<K, V>) => T, thisArg?: any): T[];
+	public flatMap<T>(fn: (value: V, key: K, collection: Collection<K, V>) => Collection<K, T>, thisArg?: any): Collection<K, T>;
 	public mapValues<T>(fn: (value: V, key: K, collection: Collection<K, V>) => T, thisArg?: any): Collection<K, T>;
 	public partition(fn: (value: V, key: K, collection: Collection<K, V>) => boolean): [Collection<K, V>, Collection<K, V>];
 	public random(): V | undefined;


### PR DESCRIPTION
Figured if collections are going to emulate basically every array method out there, it might as well also do flatMap. I wanted to add some sort of heads-up about keys possibly overriding each other with flatMap but I wasn't sure where to put it.