### PR TITLE
Add old Collection#sort as Collection#sorted

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -420,7 +420,7 @@ class Collection extends Map {
   }
 
   /**
-   * The sort() method sorts the elements of a collection and returns it.
+   * The sort method sorts the elements of a collection in place and returns it.
    * The sort is not necessarily stable. The default sort order is according to string Unicode code points.
    * @param {Function} [compareFunction] Specifies a function that defines the sort order.
    * If omitted, the collection is sorted according to each character's Unicode code point value,
@@ -436,6 +436,20 @@ class Collection extends Map {
       this.set(k, v);
     }
     return this;
+  }
+
+  /**
+   * The sorted method sorts the elements of a collection and returns it.
+   * The sort is not necessarily stable. The default sort order is according to string Unicode code points.
+   * @param {Function} [compareFunction] Specifies a function that defines the sort order.
+   * If omitted, the collection is sorted according to each character's Unicode code point value,
+   * according to the string conversion of each element.
+   * @returns {Collection}
+   * @example collection.sorted((userA, userB) => userA.createdTimestamp - userB.createdTimestamp);
+   */
+  sorted(compareFunction = (x, y) => +(x > y) || +(x === y) - 1) {
+    return new this.constructor[Symbol.species]([...this.entries()]
+      .sort((a, b) => compareFunction(a[1], b[1], a[0], b[0])));
   }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -244,3 +244,14 @@ test('sort a collection in place', () => {
   coll.sort((a, b) => a - b);
   assert.deepStrictEqual(coll.array(), [1, 2, 3]);
 });
+
+test('sort a collection', () => {
+  const coll = new Collection();
+  coll.set('a', 3);
+  coll.set('b', 2);
+  coll.set('c', 1);
+  assert.deepStrictEqual(coll.array(), [3, 2, 1]);
+  const sorted = coll.sorted((a, b) => a - b);
+  assert.deepStrictEqual(coll.array(), [3, 2, 1]);
+  assert.deepStrictEqual(sorted.array(), [1, 2, 3]);
+});

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -30,6 +30,7 @@ declare class Collection<K, V> extends Map<K, V> {
 	public reduce<T>(fn: (accumulator: T, value: V, key: K, collection: Collection<K, V>) => T, initialValue?: T): T;
 	public some(fn: (value: V, key: K, collection: Collection<K, V>) => boolean, thisArg?: any): boolean;
 	public sort(compareFunction?: (a: V, b: V, c?: K, d?: K) => number): Collection<K, V>;
+	public sorted(compareFunction?: (a: V, b: V, c?: K, d?: K) => number): Collection<K, V>;
 	public sweep(fn: (value: V, key: K, collection: Collection<K, V>) => boolean, thisArg?: any): number;
 	public tap(fn: (collection: Collection<K, V>) => void, thisArg?: any): Collection<K, V>;
 }


### PR DESCRIPTION
When we want to sort in place, `coll.clone().sort()` will be slower than the old sort method, so we should add it back under the name `sorted` (a la Python).