### PR TITLE
fix: Collection#sort should not call `this.set` but `super.set`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -487,9 +487,15 @@ class Collection<K, V> extends Map<K, V> {
 	public sort(compareFunction: (firstValue: V, secondValue: V, firstKey: K, secondKey: K) => number = (x, y): number => Number(x > y) || Number(x === y) - 1): this {
 		const entries = [...this.entries()];
 		entries.sort((a, b): number => compareFunction(a[1], b[1], a[0], b[0]));
-		this.clear();
+		
+		// Perform clean-up
+		super.clear();
+		this._array = null;
+		this._keyArray = null;
+		
+		// Set the new entries
 		for (const [k, v] of entries) {
-			this.set(k, v);
+			super.set(k, v);
 		}
 		return this;
 	}


### PR DESCRIPTION
Fixes a bug when an overriden `set` method is made, such as https://github.com/discordjs/discord.js/blob/master/src/stores/GuildMemberRoleStore.js#L140-L142, when `sort` is called.

*This doesn't feel right, it's not a right fix, but it fixes the surprising behaviour of this method.*