### PR TITLE
chore(license): bump license year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2015 - 2019 Amish Shah
+   Copyright 2015 - 2020 Amish Shah
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR bumps the license year to 2020.