### PR TITLE
fix(Collection): properly export the collection class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -576,6 +576,6 @@ class Collection<K, V> extends Map<K, V> {
 	}
 }
 
+module.exports = Collection;
 export { Collection };
 export default Collection;
-module.exports = Collection;


### PR DESCRIPTION
Currently the collection class is being exported in the following way:
```ts
export { Collection };
export default Collection;
module.exports = Collection;
```

The compiled code looks as follows:
```js
exports.Collection = Collection;
Collection.default = Collection;
exports.default = Collection;
module.exports = Collection;
```

The issue at hand is obvious, the `exports` object is added a `Collection` and a `default` property with the class itself, but then the `exports` object is overwritten with the class, causing the following, for instance, to be invalid.
```ts
import { Collection } from '@discordjs/collection';
```

This PR fixes this by re-ordering the exports.