### PR TITLE
fix: random* returning undefined vals when > collection size

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -195,7 +195,7 @@ class Collection<K, V> extends Map<K, V> {
 		if (typeof amount === 'undefined') return arr[Math.floor(Math.random() * arr.length)];
 		if (arr.length === 0 || !amount) return [];
 		arr = arr.slice();
-		return Array.from({ length: amount }, (): V => arr.splice(Math.floor(Math.random() * arr.length), 1)[0]);
+		return Array.from({ length: Math.min(amount, arr.length) }, (): V => arr.splice(Math.floor(Math.random() * arr.length), 1)[0]);
 	}
 
 	/**
@@ -211,7 +211,7 @@ class Collection<K, V> extends Map<K, V> {
 		if (typeof amount === 'undefined') return arr[Math.floor(Math.random() * arr.length)];
 		if (arr.length === 0 || !amount) return [];
 		arr = arr.slice();
-		return Array.from({ length: amount }, (): K => arr.splice(Math.floor(Math.random() * arr.length), 1)[0]);
+		return Array.from({ length: Math.min(amount, arr.length) }, (): K => arr.splice(Math.floor(Math.random() * arr.length), 1)[0]);
 	}
 
 	/**

--- a/test/index.js
+++ b/test/index.js
@@ -280,7 +280,7 @@ test('when random param > collection size', () => {
 	coll.set('c', 1);
 
 	const random = coll.random(5);
-	assert.ok(random.length === coll.size, "Random returned more elemants than the collection size");
+	assert.ok(random.length === coll.size, "Random returned more elements than the collection size");
 });
 
 test('sort a collection', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -273,6 +273,16 @@ test('random select from a collection', () => {
 	assert.ok(set.size === random.length, 'Random returned the same elements X times');
 });
 
+test('when random param > collection size', () => {
+	const coll = new Collection();
+	coll.set('a', 3);
+	coll.set('b', 2);
+	coll.set('c', 1);
+
+	const random = coll.random(5);
+	assert.ok(random.length === coll.size, "Random returned more elemants than the collection size");
+});
+
 test('sort a collection', () => {
   const coll = new Collection();
   coll.set('a', 3);


### PR DESCRIPTION
This PR updates the logic for `random*` functions when the number of random values requested is greater than the size of the collection.

Closes #27.

