### PR TITLE
feat(random): Make `get` more generic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ class Collection<K, V> extends Map<K, V> {
 	 * @param {*} key - The key to get from this collection
 	 * @returns {* | undefined}
 	 */
-	public get(key: K): V | undefined {
+	public get<R extends V = V>(key: K): R | undefined {
 		return super.get(key);
 	}
 


### PR DESCRIPTION
This allows for having a collection with Value of any type, while still being able to specify the expected return type from the get, without casting