### PR TITLE
refactor: remove array methods and caching mechanism

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,30 +13,8 @@ export interface CollectionConstructor {
  * @property {number} size - The amount of elements in this collection.
  */
 class Collection<K, V> extends Map<K, V> {
-	private _array!: V[] | null;
-	private _keyArray!: K[] | null;
 	public static readonly default: typeof Collection = Collection;
 	public ['constructor']: typeof Collection;
-
-	public constructor(entries?: ReadonlyArray<readonly [K, V]> | null) {
-		super(entries);
-
-		/**
-		 * Cached array for the `array()` method - will be reset to `null` whenever `set()` or `delete()` are called
-		 * @name Collection#_array
-		 * @type {?Array}
-		 * @private
-		 */
-		Object.defineProperty(this, '_array', { value: null, writable: true, configurable: true });
-
-		/**
-		 * Cached array for the `keyArray()` method - will be reset to `null` whenever `set()` or `delete()` are called
-		 * @name Collection#_keyArray
-		 * @type {?Array}
-		 * @private
-		 */
-		Object.defineProperty(this, '_keyArray', { value: null, writable: true, configurable: true });
-	}
 
 	/**
 	 * Identical to [Map.get()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get).
@@ -56,8 +34,6 @@ class Collection<K, V> extends Map<K, V> {
 	 * @returns {Collection}
 	 */
 	public set(key: K, value: V): this {
-		this._array = null;
-		this._keyArray = null;
 		return super.set(key, value);
 	}
 
@@ -78,8 +54,6 @@ class Collection<K, V> extends Map<K, V> {
 	 * @returns {boolean} `true` if the element was removed, `false` if the element does not exist.
 	 */
 	public delete(key: K): boolean {
-		this._array = null;
-		this._keyArray = null;
 		return super.delete(key);
 	}
 
@@ -90,30 +64,6 @@ class Collection<K, V> extends Map<K, V> {
 	 */
 	public clear(): void {
 		return super.clear();
-	}
-
-	/**
-	 * Creates an ordered array of the values of this collection, and caches it internally. The array will only be
-	 * reconstructed if an item is added to or removed from the collection, or if you change the length of the array
-	 * itself. If you don't want this caching behavior, use `[...collection.values()]` or
-	 * `Array.from(collection.values())` instead.
-	 * @returns {Array}
-	 */
-	public array(): V[] {
-		if (this._array?.length !== this.size) this._array = [...this.values()];
-		return this._array;
-	}
-
-	/**
-	 * Creates an ordered array of the keys of this collection, and caches it internally. The array will only be
-	 * reconstructed if an item is added to or removed from the collection, or if you change the length of the array
-	 * itself. If you don't want this caching behavior, use `[...collection.keys()]` or
-	 * `Array.from(collection.keys())` instead.
-	 * @returns {Array}
-	 */
-	public keyArray(): K[] {
-		if (this._keyArray?.length !== this.size) this._keyArray = [...this.keys()];
-		return this._keyArray;
 	}
 
 	/**
@@ -149,8 +99,7 @@ class Collection<K, V> extends Map<K, V> {
 	}
 
 	/**
-	 * Obtains the last value(s) in this collection. This relies on {@link Collection#array}, and thus the caching
-	 * mechanism applies here as well.
+	 * Obtains the last value(s) in this collection.
 	 * @param {number} [amount] Amount of values to obtain from the end
 	 * @returns {*|Array<*>} A single value if no amount is provided or an array of values, starting from the start if
 	 * amount is negative
@@ -158,7 +107,7 @@ class Collection<K, V> extends Map<K, V> {
 	public last(): V | undefined;
 	public last(amount: number): V[];
 	public last(amount?: number): V | V[] | undefined {
-		const arr = this.array();
+		const arr = [...this.values()];
 		if (typeof amount === 'undefined') return arr[arr.length - 1];
 		if (amount < 0) return this.first(amount * -1);
 		if (!amount) return [];
@@ -166,8 +115,7 @@ class Collection<K, V> extends Map<K, V> {
 	}
 
 	/**
-	 * Obtains the last key(s) in this collection. This relies on {@link Collection#keyArray}, and thus the caching
-	 * mechanism applies here as well.
+	 * Obtains the last key(s) in this collection.
 	 * @param {number} [amount] Amount of keys to obtain from the end
 	 * @returns {*|Array<*>} A single key if no amount is provided or an array of keys, starting from the start if
 	 * amount is negative
@@ -175,7 +123,7 @@ class Collection<K, V> extends Map<K, V> {
 	public lastKey(): K | undefined;
 	public lastKey(amount: number): K[];
 	public lastKey(amount?: number): K | K[] | undefined {
-		const arr = this.keyArray();
+		const arr = [...this.keys()];
 		if (typeof amount === 'undefined') return arr[arr.length - 1];
 		if (amount < 0) return this.firstKey(amount * -1);
 		if (!amount) return [];
@@ -183,18 +131,16 @@ class Collection<K, V> extends Map<K, V> {
 	}
 
 	/**
-	 * Obtains unique random value(s) from this collection. This relies on {@link Collection#array}, and thus the caching
-	 * mechanism applies here as well.
+	 * Obtains unique random value(s) from this collection.
 	 * @param {number} [amount] Amount of values to obtain randomly
 	 * @returns {*|Array<*>} A single value if no amount is provided or an array of values
 	 */
 	public random(): V;
 	public random(amount: number): V[];
 	public random(amount?: number): V | V[] {
-		let arr = this.array();
+		const arr = [...this.values()];
 		if (typeof amount === 'undefined') return arr[Math.floor(Math.random() * arr.length)];
 		if (!arr.length || !amount) return [];
-		arr = arr.slice();
 		return Array.from(
 			{ length: Math.min(amount, arr.length) },
 			(): V => arr.splice(Math.floor(Math.random() * arr.length), 1)[0],
@@ -202,18 +148,16 @@ class Collection<K, V> extends Map<K, V> {
 	}
 
 	/**
-	 * Obtains unique random key(s) from this collection. This relies on {@link Collection#keyArray}, and thus the caching
-	 * mechanism applies here as well.
+	 * Obtains unique random key(s) from this collection.
 	 * @param {number} [amount] Amount of keys to obtain randomly
 	 * @returns {*|Array<*>} A single key if no amount is provided or an array
 	 */
 	public randomKey(): K;
 	public randomKey(amount: number): K[];
 	public randomKey(amount?: number): K | K[] {
-		let arr = this.keyArray();
+		const arr = [...this.keys()];
 		if (typeof amount === 'undefined') return arr[Math.floor(Math.random() * arr.length)];
 		if (!arr.length || !amount) return [];
-		arr = arr.slice();
 		return Array.from(
 			{ length: Math.min(amount, arr.length) },
 			(): K => arr.splice(Math.floor(Math.random() * arr.length), 1)[0],
@@ -552,8 +496,6 @@ class Collection<K, V> extends Map<K, V> {
 
 		// Perform clean-up
 		super.clear();
-		this._array = null;
-		this._keyArray = null;
 
 		// Set the new entries
 		for (const [k, v] of entries) {

--- a/test/collection.test.ts
+++ b/test/collection.test.ts
@@ -17,20 +17,6 @@ test('do basic map operations', () => {
 	expect(coll.size).toStrictEqual(0);
 });
 
-test('convert collection to array with caching', () => {
-	const coll: TestCollection = new Collection();
-	coll.set('a', 1);
-	coll.set('b', 2);
-	coll.set('c', 3);
-	const array1 = coll.array();
-	expect(array1).toStrictEqual([1, 2, 3]);
-	expect(array1 === coll.array()).toBeTruthy();
-	coll.set('d', 4);
-	const array2 = coll.array();
-	expect(array2).toStrictEqual([1, 2, 3, 4]);
-	expect(array2 === coll.array()).toBeTruthy();
-});
-
 test('get the first item of the collection', () => {
 	const coll: TestCollection = new Collection();
 	coll.set('a', 1);
@@ -90,10 +76,10 @@ test('sweep items from the collection', () => {
 	coll.set('c', 3);
 	const n1 = coll.sweep((x) => x === 2);
 	expect(n1).toStrictEqual(1);
-	expect(coll.array()).toStrictEqual([1, 3]);
+	expect([...coll.values()]).toStrictEqual([1, 3]);
 	const n2 = coll.sweep((x) => x === 4);
 	expect(n2).toStrictEqual(0);
-	expect(coll.array()).toStrictEqual([1, 3]);
+	expect([...coll.values()]).toStrictEqual([1, 3]);
 });
 
 test('filter items from the collection', () => {
@@ -104,7 +90,7 @@ test('filter items from the collection', () => {
 	const filtered = coll.filter((x) => x % 2 === 1);
 	expect(coll.size).toStrictEqual(3);
 	expect(filtered.size).toStrictEqual(2);
-	expect(filtered.array()).toStrictEqual([1, 3]);
+	expect([...filtered.values()]).toStrictEqual([1, 3]);
 });
 
 test('partition a collection into two collections', () => {
@@ -116,8 +102,8 @@ test('partition a collection into two collections', () => {
 	coll.set('e', 5);
 	coll.set('f', 6);
 	const [even, odd] = coll.partition((x) => x % 2 === 0);
-	expect(even.array()).toStrictEqual([2, 4, 6]);
-	expect(odd.array()).toStrictEqual([1, 3, 5]);
+	expect([...even.values()]).toStrictEqual([2, 4, 6]);
+	expect([...odd.values()]).toStrictEqual([1, 3, 5]);
 });
 
 test('map items in a collection into an array', () => {
@@ -135,7 +121,7 @@ test('map items in a collection into a collection', () => {
 	coll.set('b', 2);
 	coll.set('c', 3);
 	const mapped = coll.mapValues((x) => x + 1);
-	expect(mapped.array()).toStrictEqual([2, 3, 4]);
+	expect([...mapped.values()]).toStrictEqual([2, 3, 4]);
 });
 
 test('flatMap items in a collection into a single collection', () => {
@@ -149,7 +135,7 @@ test('flatMap items in a collection into a single collection', () => {
 	coll.set('a', { a: coll1 });
 	coll.set('b', { a: coll2 });
 	const mapped = coll.flatMap((x) => x.a);
-	expect(mapped.array()).toStrictEqual([1, 2, 3, 4]);
+	expect([...mapped.values()]).toStrictEqual([1, 2, 3, 4]);
 });
 
 test('check if some items pass a predicate', () => {
@@ -221,7 +207,7 @@ test('shallow clone the collection', () => {
 	coll.set('b', 2);
 	coll.set('c', 3);
 	const clone = coll.clone();
-	expect(coll.array()).toStrictEqual(clone.array());
+	expect([...coll.values()]).toStrictEqual([...clone.values()]);
 });
 
 test('merge multiple collections', () => {
@@ -232,7 +218,7 @@ test('merge multiple collections', () => {
 	const coll3 = new Collection();
 	coll3.set('c', 3);
 	const merged = coll1.concat(coll2, coll3);
-	expect(merged.array()).toStrictEqual([1, 2, 3]);
+	expect([...merged.values()]).toStrictEqual([1, 2, 3]);
 	expect(coll1 !== merged).toBeTruthy();
 });
 
@@ -253,9 +239,9 @@ test('sort a collection in place', () => {
 	coll.set('a', 3);
 	coll.set('b', 2);
 	coll.set('c', 1);
-	expect(coll.array()).toStrictEqual([3, 2, 1]);
+	expect([...coll.values()]).toStrictEqual([3, 2, 1]);
 	coll.sort((a, b) => a - b);
-	expect(coll.array()).toStrictEqual([1, 2, 3]);
+	expect([...coll.values()]).toStrictEqual([1, 2, 3]);
 });
 
 test('random select from a collection', () => {
@@ -287,10 +273,10 @@ test('sort a collection', () => {
 	coll.set('a', 3);
 	coll.set('b', 2);
 	coll.set('c', 1);
-	expect(coll.array()).toStrictEqual([3, 2, 1]);
+	expect([...coll.values()]).toStrictEqual([3, 2, 1]);
 	const sorted = coll.sorted((a, b) => a - b);
-	expect(coll.array()).toStrictEqual([3, 2, 1]);
-	expect(sorted.array()).toStrictEqual([1, 2, 3]);
+	expect([...coll.values()]).toStrictEqual([3, 2, 1]);
+	expect([...sorted.values()]).toStrictEqual([1, 2, 3]);
 });
 
 describe('random thisArg tests', () => {


### PR DESCRIPTION
"When the collection is small, the values are barely added/removed, but creating arrays on the fly are so fast it's negligible. When the collection is big, the values are added/removed very often, which voids the array almost instantly, forcing re-arrays anyways."
~ @kyranet, 2021

Removing the caching mechanism also makes the methods obsolete.