### PR TITLE
ci: create jest/docs testing workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,8 @@
-name: Tests
+name: Testing
 on: [push, pull_request]
 jobs:
-  test:
-    name: Test
+  lint:
+    name: ESLint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -14,10 +14,7 @@ jobs:
           node-version: 14
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
-      - name: Run Jest Tests
-        run: npm run test
-
-      - name: Run Documentation Tests
-        run: npm run docs:test
+      - name: Run ESLint
+        uses: icrawl/action-eslint@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
           node-version: 14
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Run Jest Tests
         run: npm run test


### PR DESCRIPTION
This PR creates a workflow for running both documentation and Jest tests.
The aforementioned workflow is within  `test.yml` and the linting job has been moved into `lint.yml`.