### PR TITLE
feat: add hasAll() and hasAny()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,18 +93,18 @@ class Collection<K, V> extends Map<K, V> {
 	}
 
 	/**
-	 * Checks if any of the elements exist in the collection.
+	 * Checks if all of the elements exist in the collection.
 	 * @param {...*} keys - The keys of the elements to check for
-	 * @returns {boolean} `true` if any of the elements exist, `false` if none exist.
+	 * @returns {boolean} `true` if all of the elements exist, `false` if at least one does not exist.
 	 */
 	public hasAll(...keys: K[]): boolean {
 		return keys.every((k) => super.has(k));
 	}
 
 	/**
-	 * Checks if all of the elements exist in the collection.
+	 * Checks if any of the elements exist in the collection.
 	 * @param {...*} keys - The keys of the elements to check for
-	 * @returns {boolean} `true` if all of the elements exist, `false` if at least one does not exist.
+	 * @returns {boolean} `true` if any of the elements exist, `false` if none exist.
 	 */
 	public hasAny(...keys: K[]): boolean {
 		return keys.some((k) => super.has(k));

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,13 +62,13 @@ class Collection<K, V> extends Map<K, V> {
 	}
 
 	/**
-	 * Based on [Map.has()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has).
-	 * Checks if one or multiple elements exist in the collection.
-	 * @param {...*} keys - The keys of the elements to check for
-	 * @returns {boolean} `true` if the elements exist, `false` if they do not exist.
+	 * Identical to [Map.has()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has).
+	 * Checks if an element exists in the collection.
+	 * @param {*} key - The key of the element to check for
+	 * @returns {boolean} `true` if the element exists, `false` if it does not exist.
 	 */
-	public has(...keys: K[]): boolean {
-		return keys.every((k) => super.has(k));
+	public has(key: K): boolean {
+		return super.has(key);
 	}
 
 	/**
@@ -97,7 +97,16 @@ class Collection<K, V> extends Map<K, V> {
 	 * @param {...*} keys - The keys of the elements to check for
 	 * @returns {boolean} `true` if any of the elements exist, `false` if none exist.
 	 */
-	public any(...keys: K[]): boolean {
+	public hasAll(...keys: K[]): boolean {
+		return keys.every((k) => super.has(k));
+	}
+
+	/**
+	 * Checks if all of the elements exist in the collection.
+	 * @param {...*} keys - The keys of the elements to check for
+	 * @returns {boolean} `true` if all of the elements exist, `false` if at least one does not exist.
+	 */
+	public hasAny(...keys: K[]): boolean {
 		return keys.some((k) => super.has(k));
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,13 +62,13 @@ class Collection<K, V> extends Map<K, V> {
 	}
 
 	/**
-	 * Identical to [Map.has()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has).
-	 * Checks if an element exists in the collection.
-	 * @param {*} key - The key of the element to check for
-	 * @returns {boolean} `true` if the element exists, `false` if it does not exist.
+	 * Based on [Map.has()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has).
+	 * Checks if one or multiple elements exist in the collection.
+	 * @param {...*} keys - The keys of the elements to check for
+	 * @returns {boolean} `true` if the elements exist, `false` if they do not exist.
 	 */
-	public has(key: K): boolean {
-		return super.has(key);
+	public has(...keys: K[]): boolean {
+		return keys.every((k) => super.has(k));
 	}
 
 	/**
@@ -90,6 +90,15 @@ class Collection<K, V> extends Map<K, V> {
 	 */
 	public clear(): void {
 		return super.clear();
+	}
+
+	/**
+	 * Checks if any of the elements exist in the collection.
+	 * @param {...*} keys - The keys of the elements to check for
+	 * @returns {boolean} `true` if any of the elements exist, `false` if none exist.
+	 */
+	public any(...keys: K[]): boolean {
+		return keys.some((k) => super.has(k));
 	}
 
 	/**

--- a/test/collection.test.ts
+++ b/test/collection.test.ts
@@ -17,16 +17,16 @@ test('do basic map operations', () => {
 	expect(coll.size).toStrictEqual(0);
 });
 
-test('use has() and any() with multiple elements', () => {
+test('use hasAll() and hasAny()', () => {
 	const coll: TestCollection = new Collection();
 	coll.set('a', 1);
 	coll.set('b', 2);
-	expect(coll.has('a', 'b')).toBeTruthy();
-	expect(coll.has('a', 'c')).toBeFalsy();
-	expect(coll.has('c', 'd')).toBeFalsy();
-	expect(coll.any('a', 'b')).toBeTruthy();
-	expect(coll.any('a', 'c')).toBeTruthy();
-	expect(coll.any('c', 'd')).toBeFalsy();
+	expect(coll.hasAll('a', 'b')).toBeTruthy();
+	expect(coll.hasAll('a', 'c')).toBeFalsy();
+	expect(coll.hasAll('c', 'd')).toBeFalsy();
+	expect(coll.hasAny('a', 'b')).toBeTruthy();
+	expect(coll.hasAny('a', 'c')).toBeTruthy();
+	expect(coll.hasAny('c', 'd')).toBeFalsy();
 });
 
 test('convert collection to array with caching', () => {

--- a/test/collection.test.ts
+++ b/test/collection.test.ts
@@ -17,18 +17,6 @@ test('do basic map operations', () => {
 	expect(coll.size).toStrictEqual(0);
 });
 
-test('use hasAll() and hasAny()', () => {
-	const coll: TestCollection = new Collection();
-	coll.set('a', 1);
-	coll.set('b', 2);
-	expect(coll.hasAll('a', 'b')).toBeTruthy();
-	expect(coll.hasAll('a', 'c')).toBeFalsy();
-	expect(coll.hasAll('c', 'd')).toBeFalsy();
-	expect(coll.hasAny('a', 'b')).toBeTruthy();
-	expect(coll.hasAny('a', 'c')).toBeTruthy();
-	expect(coll.hasAny('c', 'd')).toBeFalsy();
-});
-
 test('get the first item of the collection', () => {
 	const coll: TestCollection = new Collection();
 	coll.set('a', 1);
@@ -289,6 +277,42 @@ test('sort a collection', () => {
 	const sorted = coll.sorted((a, b) => a - b);
 	expect([...coll.values()]).toStrictEqual([3, 2, 1]);
 	expect([...sorted.values()]).toStrictEqual([1, 2, 3]);
+});
+
+describe('hasAll() tests', () => {
+	const coll: TestCollection = new Collection();
+	coll.set('a', 1);
+	coll.set('b', 2);
+
+	test('All keys exist in the collection', () => {
+		expect(coll.hasAll('a', 'b')).toBeTruthy();
+	});
+
+	test('Some keys exist in the collection', () => {
+		expect(coll.hasAll('b', 'c')).toBeFalsy();
+	});
+
+	test('No keys exist in the collection', () => {
+		expect(coll.hasAll('c', 'd')).toBeFalsy();
+	});
+});
+
+describe('hasAny() tests', () => {
+	const coll: TestCollection = new Collection();
+	coll.set('a', 1);
+	coll.set('b', 2);
+
+	test('All keys exist in the collection', () => {
+		expect(coll.hasAny('a', 'b')).toBeTruthy();
+	});
+
+	test('Some keys exist in the collection', () => {
+		expect(coll.hasAny('b', 'c')).toBeTruthy();
+	});
+
+	test('No keys exist in the collection', () => {
+		expect(coll.hasAny('c', 'd')).toBeFalsy();
+	});
 });
 
 describe('random thisArg tests', () => {

--- a/test/collection.test.ts
+++ b/test/collection.test.ts
@@ -17,6 +17,18 @@ test('do basic map operations', () => {
 	expect(coll.size).toStrictEqual(0);
 });
 
+test('use has() and any() with multiple elements', () => {
+	const coll: TestCollection = new Collection();
+	coll.set('a', 1);
+	coll.set('b', 2);
+	expect(coll.has('a', 'b')).toBeTruthy();
+	expect(coll.has('a', 'c')).toBeFalsy();
+	expect(coll.has('c', 'd')).toBeFalsy();
+	expect(coll.any('a', 'b')).toBeTruthy();
+	expect(coll.any('a', 'c')).toBeTruthy();
+	expect(coll.any('c', 'd')).toBeFalsy();
+});
+
 test('convert collection to array with caching', () => {
 	const coll: TestCollection = new Collection();
 	coll.set('a', 1);


### PR DESCRIPTION
This allows users to pass multiple parameters to `has()`, checking if all of the keys exist, and adds a method `any()` which checks if any of the keys exist. The naming came from the discord.js `BitField` class.

I can imagine this to be extremely useful, for example when you need to check if a guild member has multiple or one of multiple roles.