### PR TITLE
Update filter overloads to support filtering with type guards

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -287,7 +287,10 @@ class Collection<K, V> extends Map<K, V> {
 	 * @example collection.filter(user => user.username === 'Bob');
 	 */
 	public filter(fn: (value: V, key: K, collection: this) => boolean): this;
-	public filter<T>(fn: (this: T, value: V, key: K, collection: this) => boolean, thisArg: T): this;
+	public filter<T extends V>(
+		fn: (value: V, key: K, collection: this) => value is T,
+		thisArg?: unknown,
+	): Collection<K, T>;
 	public filter(fn: (value: V, key: K, collection: this) => boolean, thisArg?: unknown): this {
 		if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
 		const results = new this.constructor[Symbol.species]<K, V>() as this;


### PR DESCRIPTION
~~Let's try this again~~
Currently, types for `filter` don't really play along with type predicates:
```ts
class A { type = 'a' }
class B { type = 'b' }
const coll = new Collection<string, A | B>();

const isA(x: A | B): x is A => x.type === 'a';

const c1 = coll.filter(isA); 			// Collection<string, A | B>
const c2 = coll.filter(isA, new A); 	// Collection<string, A | B>
const c3 = coll.filter<A>(isA); 		// Error, no 'thisArg'
const c4 = coll.filter<A>(isA, new A); 	// Collection<string, A | B>
```

New overload partially fixes that problem in similar fashion node's `Array.filter` does, allowing 3 out of 4 filters from above to provide correct type.

```ts
const c5 = coll.filter(isA); 			// Collection<string, A | B>
const c6 = coll.filter(isA, new A); 	// Collection<string, A>
const c7 = coll.filter<A>(isA); 		// Collection<string, A>
const c8 = coll.filter<A>(isA, new A); 	// Collection<string, A>

const thisWorksOnArrayThough = coll.map(x => x).filter(isA) // A[]
```

I have no clue if this is correct way to do this or if it should be done in other functions as well (or why does the `Array` overload work in every case listed above)