### PR TITLE
feat: add Collection#ensure

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ export class Collection<K, V> extends Map<K, V> {
 
 	/**
 	 * Gets an element if the key exists, otherwise sets and returns the provided default value.
-	 * @param {*} key - Key to get from/set to the collection.
+	 * @param {*} key - Key to ensure from the collection.
 	 * @param {function} getDefaultValue - Function that returns the default value to be set and returned if the key doesn't exist.
 	 * @returns {*} The existing value if any, the provided return value otherwise.
 	 */

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,8 @@ export class Collection<K, V> extends Map<K, V> {
 	 * @returns {*}
 	 */
 	public ensure(key: K, defaultValue: V): V {
-		if (this.has(key)) return this.get(key)!;
+		const value = this.get(key);
+		if (typeof value !== 'undefined') return value;
 		this.set(key, defaultValue);
 		return defaultValue;
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ export class Collection<K, V> extends Map<K, V> {
 	}
 
 	/**
-	 * Gets an element if the key exists, otherwise sets it to {@param defaultValue} and returns the {@param defaultValue}.
+	 * Gets an element if the key exists, otherwise sets and returns {@param defaultValue}.
 	 * @param {*} key - Key to get from/set to the collection.
 	 * @param {*} defaultValue - Default value to be set and returned if the key doesn't exist.
 	 * @returns {*}

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,18 @@ export class Collection<K, V> extends Map<K, V> {
 	}
 
 	/**
+	 * Gets an element if the key exists, otherwise sets it to {@param defaultValue} and returns the {@param defaultValue}.
+	 * @param {*} key - Key to get from/set to the collection.
+	 * @param {*} defaultValue - Default value to be set and returned if the key doesn't exist.
+	 * @returns {*}
+	 */
+	public ensure(key: K, defaultValue: V): V {
+		if (this.has(key)) return this.get(key)!;
+		this.set(key, defaultValue);
+		return defaultValue;
+	}
+
+	/**
 	 * Checks if all of the elements exist in the collection.
 	 * @param {...*} keys - The keys of the elements to check for
 	 * @returns {boolean} `true` if all of the elements exist, `false` if at least one does not exist.

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ export class Collection<K, V> extends Map<K, V> {
 	 * Gets an element if the key exists, otherwise sets and returns {@param defaultValue}.
 	 * @param {*} key - Key to get from/set to the collection.
 	 * @param {*} defaultValue - Default value to be set and returned if the key doesn't exist.
-	 * @returns {*}
+	 * @returns {*} The existing value if any, {@param defaultValue} otherwise.
 	 */
 	public ensure(key: K, defaultValue: V): V {
 		const value = this.get(key);

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,24 +71,6 @@ export class Collection<K, V> extends Map<K, V> {
 	 * @param {*} key - Key to get from/set to the collection.
 	 * @param {function} getDefaultValue - Function that returns the default value to be set and returned if the key doesn't exist.
 	 * @returns {*} The existing value if any, {@param getDefaultValue}'s return value otherwise.
-	 * @example <caption>Example use case: per-guild settings</caption>
-	 * // should be customized for what your bot needs
-	 * const defaultSettings = {
-	 *   welcomeChannelID: null,
-	 *   reactionRoleMessageID: null,
-	 *   adminRoleID: null,
-	 *   muteRoleID: null
-	 * }
-	 *
-	 * client.on('guildMemberAdd', member => {
-	 *   const getGuildSettings = client.settings.ensure(message.guild.id, () => defaultSettings);
-	 *
-	 *   // use the data
-	 *   if (guildSettings.welcomeChannelID) {
-	 *     const channel = client.channels.fetch(guildSettings.welcomeChannelID);
-	 *     channel.send(`Hello <@${member.id}>, welcome to ${member.guild.name}! Enjoy your stay!`);
-	 *   }
-	 * })
 	 */
 	public ensure(key: K, getDefaultValue: () => V): V {
 		if (this.has(key)) return this.get(key)!;

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,10 +67,10 @@ export class Collection<K, V> extends Map<K, V> {
 	}
 
 	/**
-	 * Gets an element if the key exists, otherwise sets and returns {@param getDefaultValue}'s return value.
+	 * Gets an element if the key exists, otherwise sets and returns the provided default value.
 	 * @param {*} key - Key to get from/set to the collection.
 	 * @param {function} getDefaultValue - Function that returns the default value to be set and returned if the key doesn't exist.
-	 * @returns {*} The existing value if any, {@param getDefaultValue}'s return value otherwise.
+	 * @returns {*} The existing value if any, the provided return value otherwise.
 	 */
 	public ensure(key: K, getDefaultValue: () => V): V {
 		if (this.has(key)) return this.get(key)!;

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,13 +70,35 @@ export class Collection<K, V> extends Map<K, V> {
 	 * Gets an element if the key exists, otherwise sets and returns {@param defaultValue}.
 	 * @param {*} key - Key to get from/set to the collection.
 	 * @param {*} defaultValue - Default value to be set and returned if the key doesn't exist.
-	 * @returns {*} The existing value if any, {@param defaultValue} otherwise.
+	 * @returns {function} Function that lazily evaluates to the existing value if any, {@param defaultValue} otherwise.
+	 * @example <caption>Example use case: per-guild settings</caption>
+	 * // should be customized for what your bot needs
+	 * const defaultSettings = {
+	 *   welcomeChannelID: null,
+	 *   reactionRoleMessageID: null,
+	 *   adminRoleID: null,
+	 *   muteRoleID: null
+	 * }
+	 *
+	 * client.on('guildMemberAdd', member => {
+	 *   const getGuildSettings = client.settings.ensure(message.guild.id, defaultSettings);
+	 *   // ...
+	 *
+	 *   // evaluate the data when you need it
+	 *   const guildSettings = getGuildSettings();
+	 *
+	 *   // use the data
+	 *   if (guildSettings.welcomeChannelID) {
+	 *     const channel = client.channels.fetch(guildSettings.welcomeChannelID);
+	 *     channel.send(`Hello <@${member.id}>, welcome to ${member.guild.name}! Enjoy your stay!`);
+	 *   }
+	 * })
 	 */
-	public ensure(key: K, defaultValue: V): V {
+	public ensure(key: K, defaultValue: V): () => V {
 		const value = this.get(key);
-		if (typeof value !== 'undefined') return value;
+		if (typeof value !== 'undefined') return () => value;
 		this.set(key, defaultValue);
-		return defaultValue;
+		return () => defaultValue;
 	}
 
 	/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,9 +67,9 @@ export class Collection<K, V> extends Map<K, V> {
 	}
 
 	/**
-	 * Gets an element if the key exists, otherwise sets and returns {@param defaultValue}.
+	 * Gets an element if the key exists, otherwise sets and returns {@param getDefaultValue}'s return value.
 	 * @param {*} key - Key to get from/set to the collection.
-	 * @param {*} getDefaultValue - Function that returns the default value to be set and returned if the key doesn't exist.
+	 * @param {function} getDefaultValue - Function that returns the default value to be set and returned if the key doesn't exist.
 	 * @returns {*} The existing value if any, {@param getDefaultValue}'s return value otherwise.
 	 * @example <caption>Example use case: per-guild settings</caption>
 	 * // should be customized for what your bot needs
@@ -91,8 +91,7 @@ export class Collection<K, V> extends Map<K, V> {
 	 * })
 	 */
 	public ensure(key: K, getDefaultValue: () => V): V {
-		const value = this.get(key);
-		if (typeof value !== 'undefined') return value;
+		if (this.has(key)) return this.get(key)!;
 		const defaultValue = getDefaultValue();
 		this.set(key, defaultValue);
 		return defaultValue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,8 +69,8 @@ export class Collection<K, V> extends Map<K, V> {
 	/**
 	 * Gets an element if the key exists, otherwise sets and returns {@param defaultValue}.
 	 * @param {*} key - Key to get from/set to the collection.
-	 * @param {*} defaultValue - Default value to be set and returned if the key doesn't exist.
-	 * @returns {function} Function that lazily evaluates to the existing value if any, {@param defaultValue} otherwise.
+	 * @param {*} getDefaultValue - Function that returns the default value to be set and returned if the key doesn't exist.
+	 * @returns {*} The existing value if any, {@param getDefaultValue}'s return value otherwise.
 	 * @example <caption>Example use case: per-guild settings</caption>
 	 * // should be customized for what your bot needs
 	 * const defaultSettings = {
@@ -81,11 +81,7 @@ export class Collection<K, V> extends Map<K, V> {
 	 * }
 	 *
 	 * client.on('guildMemberAdd', member => {
-	 *   const getGuildSettings = client.settings.ensure(message.guild.id, defaultSettings);
-	 *   // ...
-	 *
-	 *   // evaluate the data when you need it
-	 *   const guildSettings = getGuildSettings();
+	 *   const getGuildSettings = client.settings.ensure(message.guild.id, () => defaultSettings);
 	 *
 	 *   // use the data
 	 *   if (guildSettings.welcomeChannelID) {
@@ -94,11 +90,12 @@ export class Collection<K, V> extends Map<K, V> {
 	 *   }
 	 * })
 	 */
-	public ensure(key: K, defaultValue: V): () => V {
+	public ensure(key: K, getDefaultValue: () => V): V {
 		const value = this.get(key);
-		if (typeof value !== 'undefined') return () => value;
+		if (typeof value !== 'undefined') return value;
+		const defaultValue = getDefaultValue();
 		this.set(key, defaultValue);
-		return () => defaultValue;
+		return defaultValue;
 	}
 
 	/**

--- a/test/collection.test.ts
+++ b/test/collection.test.ts
@@ -388,21 +388,20 @@ describe('ensure() tests', () => {
 	coll.set('b', 2);
 
 	test('set new value if key does not exist', () => {
-		coll.ensure('c', 3);
+		coll.ensure('c', () => 3);
 		expect(coll.size).toStrictEqual(3);
 		expect(coll.has('c')).toBeTruthy();
 	});
 
 	test('return existing value if key exists', () => {
-		const ensureB = coll.ensure('b', 3);
-		const ensuredB = ensureB();
+		const ensureB = coll.ensure('b', () => 3);
 		const getB = coll.get('b');
-		expect(ensuredB).toBe(getB);
+		expect(ensureB).toBe(getB);
 		expect(coll.size).toStrictEqual(3);
 	});
 
 	test('ensure with existing key should not change the collection', () => {
-		coll.ensure('a', 4);
+		coll.ensure('a', () => 4);
 		expect(coll.size).toStrictEqual(3);
 		expect(coll.get('a')).toStrictEqual(1);
 	});

--- a/test/collection.test.ts
+++ b/test/collection.test.ts
@@ -400,7 +400,7 @@ describe('ensure() tests', () => {
 		expect(coll.size).toStrictEqual(3);
 	});
 
-	test('ensure when key exists should not change the collection', () => {
+	test('ensure with existing key should not change the collection', () => {
 		coll.ensure('a', 4);
 		expect(coll.size).toStrictEqual(3);
 		expect(coll.get('a')).toStrictEqual(1);

--- a/test/collection.test.ts
+++ b/test/collection.test.ts
@@ -381,3 +381,28 @@ describe('random thisArg tests', () => {
 		}, array);
 	});
 });
+
+describe('ensure() tests', () => {
+	const coll = new Collection();
+	coll.set('a', 1);
+	coll.set('b', 2);
+
+	test('set new value if key does not exist', () => {
+		coll.ensure('c', 3);
+		expect(coll.size).toStrictEqual(3);
+		expect(coll.has('c')).toBeTruthy();
+	});
+
+	test('return existing value if key exists', () => {
+		const ensureB = coll.ensure('b', 3);
+		const getB = coll.get('b');
+		expect(ensureB).toBe(getB);
+		expect(coll.size).toStrictEqual(3);
+	});
+
+	test('ensure when key exists should not change the collection', () => {
+		coll.ensure('a', 4);
+		expect(coll.size).toStrictEqual(3);
+		expect(coll.get('a')).toStrictEqual(1);
+	});
+});

--- a/test/collection.test.ts
+++ b/test/collection.test.ts
@@ -395,8 +395,9 @@ describe('ensure() tests', () => {
 
 	test('return existing value if key exists', () => {
 		const ensureB = coll.ensure('b', 3);
+		const ensuredB = ensureB();
 		const getB = coll.get('b');
-		expect(ensureB).toBe(getB);
+		expect(ensuredB).toBe(getB);
 		expect(coll.size).toStrictEqual(3);
 	});
 


### PR DESCRIPTION
Inspired by [Enmap](https://enmap.evie.dev)`#ensure`, `Collection#ensure` gets an element with the specified key if it exists, otherwise sets it to the provided `defaultValue` and returns the `defaultValue`. Useful for things like per-guild settings where you want to get it or set it to a default value all in one call.