### PR TITLE
feat: add toJSON

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -609,6 +609,11 @@ export class Collection<K, V> extends Map<K, V> {
 		return new this.constructor[Symbol.species](this).sort((av, bv, ak, bk) => compareFunction(av, bv, ak, bk));
 	}
 
+	public toJSON() {
+		// toJSON is called recursively by JSON.stringify.
+		return [...this.values()];
+	}
+
 	private static defaultSort<V>(firstValue: V, secondValue: V): number {
 		return Number(firstValue > secondValue) || Number(firstValue === secondValue) - 1;
 	}


### PR DESCRIPTION
Plan: Add `toJSON` to here, remove it from discord.js.
Problem: discord.js additionally uses `Util.flatten` for things that don't have `toJSON`. What that implies I have no idea.