### PR TITLE
feat: add array utility function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -617,6 +617,14 @@ export class Collection<K, V> extends Map<K, V> {
 		return [...this.values()];
 	}
 
+	/**
+	 * Creates an ordered array of the keys of this collection.
+	 * @returns {Array}
+	 */
+	public keyArray(): K[] {
+		return [...this.keys()];
+	}
+
 	public toJSON() {
 		// toJSON is called recursively by JSON.stringify.
 		return this.array();

--- a/src/index.ts
+++ b/src/index.ts
@@ -608,10 +608,18 @@ export class Collection<K, V> extends Map<K, V> {
 	public sorted(compareFunction: Comparator<K, V> = Collection.defaultSort): Collection<K, V> {
 		return new this.constructor[Symbol.species](this).sort((av, bv, ak, bk) => compareFunction(av, bv, ak, bk));
 	}
+	
+	/**
+	 * Creates an ordered array of the values of this collection
+	 * @returns {Array}
+	 */
+	public array(): V[] {
+		return [...this.values()];
+	}
 
 	public toJSON() {
 		// toJSON is called recursively by JSON.stringify.
-		return [...this.values()];
+		return this.array();
 	}
 
 	private static defaultSort<V>(firstValue: V, secondValue: V): number {


### PR DESCRIPTION
Re-add `array` and `keyArray` functions (without caching) removed in bc9a2ef801f2be799c0f989548198ecac19a3001.
Those functions were public previusly.

When only the values of an `Collection` are needed `collection.array()` is cleaner than `[...collection.values()]` .