### PR TITLE
feat: add #reverse

### DIFF
--- a/__tests__/collection.test.ts
+++ b/__tests__/collection.test.ts
@@ -313,6 +313,18 @@ describe('hasAny() tests', () => {
 	});
 });
 
+describe('reverse() tests', () => {
+	const coll = new Collection();
+	coll.set('a', 1);
+	coll.set('b', 2);
+	coll.set('c', 3);
+
+	coll.reverse();
+
+	expect([...coll.values()]).toStrictEqual([3, 2, 1]);
+	expect([...coll.keys()]).toStrictEqual(['c', 'b', 'a']);
+});
+
 describe('random thisArg tests', () => {
 	const coll = new Collection();
 	coll.set('a', 3);

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,10 +185,8 @@ export class Collection<K, V> extends Map<K, V> {
 	/**
 	 * Identical to [Array.reverse()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse)
 	 * but returns a Collection instead of an Array.
-	 *
-	 * @returns {Collection}
 	 */
-	public reverse(): this {
+	public reverse() {
 		const entries = [...this.entries()].reverse();
 		this.clear();
 		for (const [key, value] of entries) this.set(key, value);

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,6 +185,7 @@ export class Collection<K, V> extends Map<K, V> {
 	/**
 	 * Identical to [Array.reverse()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse)
 	 * but returns a Collection instead of an Array.
+	 *
 	 * @returns {Collection}
 	 */
 	public reverse(): this {

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,6 +183,18 @@ export class Collection<K, V> extends Map<K, V> {
 	}
 
 	/**
+	 * Identical to [Array.reverse()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse)
+	 * but returns a Collection instead of an Array.
+	 * @returns {Collection}
+	 */
+	public reverse(): this {
+		const entries = [...this.entries()].reverse();
+		this.clear();
+		for (const [key, value] of entries) this.set(key, value);
+		return this;
+	}
+
+	/**
 	 * Searches for a single item where the given function returns a truthy value. This behaves like
 	 * [Array.find()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find).
 	 * <warn>All collections used in Discord.js are mapped using their `id` property, and if you want to find by id you


### PR DESCRIPTION
This PR adds the Collection#reverse method, which works similarly to Array#reverse by reversing the order of a Collection's entries. Although Collections don't have indexes like arrays do, collections can be sorted, and thus a way to easily reverse this order would be nice to have.