### PR TITLE
types(At): make index a required parameter

### DIFF
--- a/__tests__/collection.test.ts
+++ b/__tests__/collection.test.ts
@@ -282,10 +282,6 @@ describe('at() tests', () => {
 	coll.set('a', 1);
 	coll.set('b', 2);
 
-	test('No index', () => {
-		expect(coll.at()).toStrictEqual(1);
-	});
-
 	test('Positive index', () => {
 		expect(coll.at(0)).toStrictEqual(1);
 	});
@@ -307,10 +303,6 @@ describe('keyAt() tests', () => {
 	const coll: TestCollection = new Collection();
 	coll.set('a', 1);
 	coll.set('b', 2);
-
-	test('No index', () => {
-		expect(coll.keyAt()).toStrictEqual('a');
-	});
 
 	test('Positive index', () => {
 		expect(coll.keyAt(0)).toStrictEqual('a');

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,7 @@ export class Collection<K, V> extends Map<K, V> {
 	 *
 	 * @param index The index of the element to obtain
 	 */
-	public at(index = 0) {
+	public at(index: number) {
 		index = Math.floor(index);
 		const arr = [...this.values()];
 		return arr.at(index);
@@ -138,7 +138,7 @@ export class Collection<K, V> extends Map<K, V> {
 	 *
 	 * @param index The index of the key to obtain
 	 */
-	public keyAt(index = 0) {
+	public keyAt(index: number) {
 		index = Math.floor(index);
 		const arr = [...this.keys()];
 		return arr.at(index);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changes the typings for Collection#at and Collection#keyAt making the index parameter required. I labeled this as a types change because passing no index is still technically valid, but it was chosen to be considered invalid in TypeScript in the [PR](https://github.com/microsoft/TypeScript/pull/46291#discussion_r738796155) that introduced the es2022 lib, which came with Array.at() type definitions

**Status and versioning classification:**
- Code changes have been tested, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
