### PR TITLE
feat: add Collection#ensure

### DIFF
--- a/__tests__/collection.test.ts
+++ b/__tests__/collection.test.ts
@@ -449,8 +449,9 @@ describe('ensure() tests', () => {
 
 	test('return existing value if key exists', () => {
 		const ensureB = coll.ensure('b', 3);
+		const ensuredB = ensureB();
 		const getB = coll.get('b');
-		expect(ensureB).toBe(getB);
+		expect(ensuredB).toBe(getB);
 		expect(coll.size).toStrictEqual(3);
 	});
 

--- a/__tests__/collection.test.ts
+++ b/__tests__/collection.test.ts
@@ -454,7 +454,7 @@ describe('ensure() tests', () => {
 		expect(coll.size).toStrictEqual(3);
 	});
 
-	test('ensure when key exists should not change the collection', () => {
+	test('ensure with existing key should not change the collection', () => {
 		coll.ensure('a', 4);
 		expect(coll.size).toStrictEqual(3);
 		expect(coll.get('a')).toStrictEqual(1);

--- a/__tests__/collection.test.ts
+++ b/__tests__/collection.test.ts
@@ -437,19 +437,22 @@ describe('random thisArg tests', () => {
 });
 
 describe('ensure() tests', () => {
+	function createTestCollection() {
+		return new Collection([
+			['a', 1],
+			['b', 2],
+		]);
+	}
+
 	test('set new value if key does not exist', () => {
-		const coll = new Collection();
-		coll.set('a', 1);
-		coll.set('b', 2);
+		const coll = createTestCollection();
 		coll.ensure('c', () => 3);
 		expect(coll.size).toStrictEqual(3);
 		expect(coll.get('c')).toStrictEqual(3);
 	});
 
 	test('return existing value if key exists', () => {
-		const coll = new Collection();
-		coll.set('a', 1);
-		coll.set('b', 2);
+		const coll = createTestCollection();
 		const ensureB = coll.ensure('b', () => 3);
 		const getB = coll.get('b');
 		expect(ensureB).toStrictEqual(2);
@@ -458,9 +461,7 @@ describe('ensure() tests', () => {
 	});
 
 	test('ensure with existing key should not change the collection', () => {
-		const coll = new Collection();
-		coll.set('a', 1);
-		coll.set('b', 2);
+		const coll = createTestCollection();
 		coll.ensure('a', () => 4);
 		expect(coll.size).toStrictEqual(2);
 		expect(coll.get('a')).toStrictEqual(1);

--- a/__tests__/collection.test.ts
+++ b/__tests__/collection.test.ts
@@ -459,11 +459,4 @@ describe('ensure() tests', () => {
 		expect(getB).toStrictEqual(2);
 		expect(coll.size).toStrictEqual(2);
 	});
-
-	test('ensure with existing key should not change the collection', () => {
-		const coll = createTestCollection();
-		coll.ensure('a', () => 4);
-		expect(coll.size).toStrictEqual(2);
-		expect(coll.get('a')).toStrictEqual(1);
-	});
 });

--- a/__tests__/collection.test.ts
+++ b/__tests__/collection.test.ts
@@ -444,13 +444,14 @@ describe('ensure() tests', () => {
 	test('set new value if key does not exist', () => {
 		coll.ensure('c', () => 3);
 		expect(coll.size).toStrictEqual(3);
-		expect(coll.has('c')).toBeTruthy();
+		expect(coll.get('c')).toStrictEqual(3);
 	});
 
 	test('return existing value if key exists', () => {
 		const ensureB = coll.ensure('b', () => 3);
 		const getB = coll.get('b');
-		expect(ensureB).toBe(getB);
+		expect(ensureB).toStrictEqual(2);
+		expect(getB).toStrictEqual(2);
 		expect(coll.size).toStrictEqual(3);
 	});
 

--- a/__tests__/collection.test.ts
+++ b/__tests__/collection.test.ts
@@ -442,21 +442,20 @@ describe('ensure() tests', () => {
 	coll.set('b', 2);
 
 	test('set new value if key does not exist', () => {
-		coll.ensure('c', 3);
+		coll.ensure('c', () => 3);
 		expect(coll.size).toStrictEqual(3);
 		expect(coll.has('c')).toBeTruthy();
 	});
 
 	test('return existing value if key exists', () => {
-		const ensureB = coll.ensure('b', 3);
-		const ensuredB = ensureB();
+		const ensureB = coll.ensure('b', () => 3);
 		const getB = coll.get('b');
-		expect(ensuredB).toBe(getB);
+		expect(ensureB).toBe(getB);
 		expect(coll.size).toStrictEqual(3);
 	});
 
 	test('ensure with existing key should not change the collection', () => {
-		coll.ensure('a', 4);
+		coll.ensure('a', () => 4);
 		expect(coll.size).toStrictEqual(3);
 		expect(coll.get('a')).toStrictEqual(1);
 	});

--- a/__tests__/collection.test.ts
+++ b/__tests__/collection.test.ts
@@ -435,3 +435,28 @@ describe('random thisArg tests', () => {
 		}, array);
 	});
 });
+
+describe('ensure() tests', () => {
+	const coll = new Collection();
+	coll.set('a', 1);
+	coll.set('b', 2);
+
+	test('set new value if key does not exist', () => {
+		coll.ensure('c', 3);
+		expect(coll.size).toStrictEqual(3);
+		expect(coll.has('c')).toBeTruthy();
+	});
+
+	test('return existing value if key exists', () => {
+		const ensureB = coll.ensure('b', 3);
+		const getB = coll.get('b');
+		expect(ensureB).toBe(getB);
+		expect(coll.size).toStrictEqual(3);
+	});
+
+	test('ensure when key exists should not change the collection', () => {
+		coll.ensure('a', 4);
+		expect(coll.size).toStrictEqual(3);
+		expect(coll.get('a')).toStrictEqual(1);
+	});
+});

--- a/__tests__/collection.test.ts
+++ b/__tests__/collection.test.ts
@@ -437,27 +437,32 @@ describe('random thisArg tests', () => {
 });
 
 describe('ensure() tests', () => {
-	const coll = new Collection();
-	coll.set('a', 1);
-	coll.set('b', 2);
-
 	test('set new value if key does not exist', () => {
+		const coll = new Collection();
+		coll.set('a', 1);
+		coll.set('b', 2);
 		coll.ensure('c', () => 3);
 		expect(coll.size).toStrictEqual(3);
 		expect(coll.get('c')).toStrictEqual(3);
 	});
 
 	test('return existing value if key exists', () => {
+		const coll = new Collection();
+		coll.set('a', 1);
+		coll.set('b', 2);
 		const ensureB = coll.ensure('b', () => 3);
 		const getB = coll.get('b');
 		expect(ensureB).toStrictEqual(2);
 		expect(getB).toStrictEqual(2);
-		expect(coll.size).toStrictEqual(3);
+		expect(coll.size).toStrictEqual(2);
 	});
 
 	test('ensure with existing key should not change the collection', () => {
+		const coll = new Collection();
+		coll.set('a', 1);
+		coll.set('b', 2);
 		coll.ensure('a', () => 4);
-		expect(coll.size).toStrictEqual(3);
+		expect(coll.size).toStrictEqual(2);
 		expect(coll.get('a')).toStrictEqual(1);
 	});
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export class Collection<K, V> extends Map<K, V> {
 	/**
 	 * Obtains an element if the key exists, otherwise sets and returns the value provided by the default value generator.
 	 *
-	 * @param {*} key - Key to ensure (if unset) or return from the collection (if set)
+	 * @param {*} key - The key to get from if it exists or set otherwise.
 	 * @param {function} defaultValueGenerator - Function that returns a value to be set (if unset) and returned afterwards
 	 *
 	 * @returns The existing value if any, otherwise the value provided by the default value generator.

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,8 @@ export class Collection<K, V> extends Map<K, V> {
 	 * @returns {*}
 	 */
 	public ensure(key: K, defaultValue: V): V {
-		if (this.has(key)) return this.get(key)!;
+		const value = this.get(key);
+		if (typeof value !== 'undefined') return value;
 		this.set(key, defaultValue);
 		return defaultValue;
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export class Collection<K, V> extends Map<K, V> {
 
 	/**
 	 * Gets an element if the key exists, otherwise sets and returns the provided default value.
-	 * @param {*} key - Key to get from/set to the collection.
+	 * @param {*} key - Key to ensure from the collection.
 	 * @param {function} getDefaultValue - Function that returns the default value to be set and returned if the key doesn't exist.
 	 * @returns {*} The existing value if any, the provided return value otherwise.
 	 */

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,8 +28,8 @@ export class Collection<K, V> extends Map<K, V> {
 	/**
 	 * Obtains an element if the key exists, otherwise sets and returns the value provided by the default value generator.
 	 *
-	 * @param {*} key - The key to get from if it exists or set otherwise.
-	 * @param {function} defaultValueGenerator - Function that returns a value to be set (if unset) and returned afterwards
+	 * @param {*} key - The key to get from if it exists or set otherwise
+	 * @param {Function} defaultValueGenerator - A function that returns the ensured value
 	 *
 	 * @returns The existing value if any, otherwise the value provided by the default value generator.
 	 *

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,8 +28,8 @@ export class Collection<K, V> extends Map<K, V> {
 	/**
 	 * Obtains the value of the given key if set, otherwise sets the value provided by the default value generator and returns it.
 	 *
-	 * @param key The key to get from if it exists or set otherwise
-	 * @param defaultValueGenerator A function that returns the ensured value
+	 * @param key The key to get if it exists, or set otherwise
+	 * @param defaultValueGenerator A function that generates the value to be set if it's missing
 	 *
 	 * @example
 	 * collection.ensure(guildId, () => defaultGuildConfig);

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,9 +26,9 @@ export class Collection<K, V> extends Map<K, V> {
 	public static readonly default: typeof Collection = Collection;
 
 	/**
-	 * Gets an element if the key exists, otherwise sets and returns {@param defaultValue}.
+	 * Gets an element if the key exists, otherwise sets and returns {@param getDefaultValue}'s return value.
 	 * @param {*} key - Key to get from/set to the collection.
-	 * @param {*} getDefaultValue - Function that returns the default value to be set and returned if the key doesn't exist.
+	 * @param {function} getDefaultValue - Function that returns the default value to be set and returned if the key doesn't exist.
 	 * @returns {*} The existing value if any, {@param getDefaultValue}'s return value otherwise.
 	 * @example <caption>Example use case: per-guild settings</caption>
 	 * // should be customized for what your bot needs
@@ -50,8 +50,7 @@ export class Collection<K, V> extends Map<K, V> {
 	 * })
 	 */
 	public ensure(key: K, getDefaultValue: () => V): V {
-		const value = this.get(key);
-		if (typeof value !== 'undefined') return value;
+		if (this.has(key)) return this.get(key)!;
 		const defaultValue = getDefaultValue();
 		this.set(key, defaultValue);
 		return defaultValue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,10 +28,8 @@ export class Collection<K, V> extends Map<K, V> {
 	/**
 	 * Obtains an element if the key exists, otherwise sets and returns the value provided by the default value generator.
 	 *
-	 * @param {*} key - The key to get from if it exists or set otherwise
-	 * @param {Function} defaultValueGenerator - A function that returns the ensured value
-	 *
-	 * @returns The existing value if any, otherwise the value provided by the default value generator.
+	 * @param key The key to get from if it exists or set otherwise
+	 * @param defaultValueGenerator A function that returns the ensured value
 	 *
 	 * @example
 	 * collection.ensure(guildId, () => defaultGuildConfig);

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,13 +29,35 @@ export class Collection<K, V> extends Map<K, V> {
 	 * Gets an element if the key exists, otherwise sets and returns {@param defaultValue}.
 	 * @param {*} key - Key to get from/set to the collection.
 	 * @param {*} defaultValue - Default value to be set and returned if the key doesn't exist.
-	 * @returns {*} The existing value if any, {@param defaultValue} otherwise.
+	 * @returns {function} Function that lazily evaluates to the existing value if any, {@param defaultValue} otherwise.
+	 * @example <caption>Example use case: per-guild settings</caption>
+	 * // should be customized for what your bot needs
+	 * const defaultSettings = {
+	 *   welcomeChannelID: null,
+	 *   reactionRoleMessageID: null,
+	 *   adminRoleID: null,
+	 *   muteRoleID: null
+	 * }
+	 *
+	 * client.on('guildMemberAdd', member => {
+	 *   const getGuildSettings = client.settings.ensure(message.guild.id, defaultSettings);
+	 *   // ...
+	 *
+	 *   // evaluate the data when you need it
+	 *   const guildSettings = getGuildSettings();
+	 *
+	 *   // use the data
+	 *   if (guildSettings.welcomeChannelID) {
+	 *     const channel = client.channels.fetch(guildSettings.welcomeChannelID);
+	 *     channel.send(`Hello <@${member.id}>, welcome to ${member.guild.name}! Enjoy your stay!`);
+	 *   }
+	 * })
 	 */
-	public ensure(key: K, defaultValue: V): V {
+	public ensure(key: K, defaultValue: V): () => V {
 		const value = this.get(key);
-		if (typeof value !== 'undefined') return value;
+		if (typeof value !== 'undefined') return () => value;
 		this.set(key, defaultValue);
-		return defaultValue;
+		return () => defaultValue;
 	}
 
 	/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export class Collection<K, V> extends Map<K, V> {
 	 * Gets an element if the key exists, otherwise sets and returns {@param defaultValue}.
 	 * @param {*} key - Key to get from/set to the collection.
 	 * @param {*} defaultValue - Default value to be set and returned if the key doesn't exist.
-	 * @returns {*}
+	 * @returns {*} The existing value if any, {@param defaultValue} otherwise.
 	 */
 	public ensure(key: K, defaultValue: V): V {
 		const value = this.get(key);

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export class Collection<K, V> extends Map<K, V> {
 	 * @example
 	 * collection.ensure(guildId, () => defaultGuildConfig);
 	 */
-	public ensure(key: K, defaultValueGenerator: (key: K, collection: this) => V): V | undefined {
+	public ensure(key: K, defaultValueGenerator: (key: K, collection: this) => V): V {
 		if (this.has(key)) return this.get(key);
 		const defaultValue = defaultValueGenerator(key, this);
 		this.set(key, defaultValue);

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,10 +26,10 @@ export class Collection<K, V> extends Map<K, V> {
 	public static readonly default: typeof Collection = Collection;
 
 	/**
-	 * Obtains the value of the given key if set, otherwise sets the value provided by the default value generator and returns it.
+	 * Obtains the value of the given key if it exists, otherwise sets and returns the value provided by the default value generator.
 	 *
 	 * @param key The key to get if it exists, or set otherwise
-	 * @param defaultValueGenerator A function that generates the value to be set if it's missing
+	 * @param defaultValueGenerator A function that generates the default value
 	 *
 	 * @example
 	 * collection.ensure(guildId, () => defaultGuildConfig);

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,24 +30,6 @@ export class Collection<K, V> extends Map<K, V> {
 	 * @param {*} key - Key to get from/set to the collection.
 	 * @param {function} getDefaultValue - Function that returns the default value to be set and returned if the key doesn't exist.
 	 * @returns {*} The existing value if any, {@param getDefaultValue}'s return value otherwise.
-	 * @example <caption>Example use case: per-guild settings</caption>
-	 * // should be customized for what your bot needs
-	 * const defaultSettings = {
-	 *   welcomeChannelID: null,
-	 *   reactionRoleMessageID: null,
-	 *   adminRoleID: null,
-	 *   muteRoleID: null
-	 * }
-	 *
-	 * client.on('guildMemberAdd', member => {
-	 *   const getGuildSettings = client.settings.ensure(message.guild.id, () => defaultSettings);
-	 *
-	 *   // use the data
-	 *   if (guildSettings.welcomeChannelID) {
-	 *     const channel = client.channels.fetch(guildSettings.welcomeChannelID);
-	 *     channel.send(`Hello <@${member.id}>, welcome to ${member.guild.name}! Enjoy your stay!`);
-	 *   }
-	 * })
 	 */
 	public ensure(key: K, getDefaultValue: () => V): V {
 		if (this.has(key)) return this.get(key)!;

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,10 +26,10 @@ export class Collection<K, V> extends Map<K, V> {
 	public static readonly default: typeof Collection = Collection;
 
 	/**
-	 * Gets an element if the key exists, otherwise sets and returns {@param getDefaultValue}'s return value.
+	 * Gets an element if the key exists, otherwise sets and returns the provided default value.
 	 * @param {*} key - Key to get from/set to the collection.
 	 * @param {function} getDefaultValue - Function that returns the default value to be set and returned if the key doesn't exist.
-	 * @returns {*} The existing value if any, {@param getDefaultValue}'s return value otherwise.
+	 * @returns {*} The existing value if any, the provided return value otherwise.
 	 */
 	public ensure(key: K, getDefaultValue: () => V): V {
 		if (this.has(key)) return this.get(key)!;

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export class Collection<K, V> extends Map<K, V> {
 	 * collection.ensure(guildId, () => defaultGuildConfig);
 	 */
 	public ensure(key: K, defaultValueGenerator: (key: K, collection: this) => V): V {
-		if (this.has(key)) return this.get(key);
+		if (this.has(key)) return this.get(key)!;
 		const defaultValue = defaultValueGenerator(key, this);
 		this.set(key, defaultValue);
 		return defaultValue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export class Collection<K, V> extends Map<K, V> {
 	public static readonly default: typeof Collection = Collection;
 
 	/**
-	 * Obtains an element if the key exists, otherwise sets and returns the value provided by the default value generator.
+	 * Obtains the value of the given key if set, otherwise sets the value provided by the default value generator and returns it.
 	 *
 	 * @param key The key to get from if it exists or set otherwise
 	 * @param defaultValueGenerator A function that returns the ensured value

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,8 +28,8 @@ export class Collection<K, V> extends Map<K, V> {
 	/**
 	 * Gets an element if the key exists, otherwise sets and returns {@param defaultValue}.
 	 * @param {*} key - Key to get from/set to the collection.
-	 * @param {*} defaultValue - Default value to be set and returned if the key doesn't exist.
-	 * @returns {function} Function that lazily evaluates to the existing value if any, {@param defaultValue} otherwise.
+	 * @param {*} getDefaultValue - Function that returns the default value to be set and returned if the key doesn't exist.
+	 * @returns {*} The existing value if any, {@param getDefaultValue}'s return value otherwise.
 	 * @example <caption>Example use case: per-guild settings</caption>
 	 * // should be customized for what your bot needs
 	 * const defaultSettings = {
@@ -40,11 +40,7 @@ export class Collection<K, V> extends Map<K, V> {
 	 * }
 	 *
 	 * client.on('guildMemberAdd', member => {
-	 *   const getGuildSettings = client.settings.ensure(message.guild.id, defaultSettings);
-	 *   // ...
-	 *
-	 *   // evaluate the data when you need it
-	 *   const guildSettings = getGuildSettings();
+	 *   const getGuildSettings = client.settings.ensure(message.guild.id, () => defaultSettings);
 	 *
 	 *   // use the data
 	 *   if (guildSettings.welcomeChannelID) {
@@ -53,11 +49,12 @@ export class Collection<K, V> extends Map<K, V> {
 	 *   }
 	 * })
 	 */
-	public ensure(key: K, defaultValue: V): () => V {
+	public ensure(key: K, getDefaultValue: () => V): V {
 		const value = this.get(key);
-		if (typeof value !== 'undefined') return () => value;
+		if (typeof value !== 'undefined') return value;
+		const defaultValue = getDefaultValue();
 		this.set(key, defaultValue);
-		return () => defaultValue;
+		return defaultValue;
 	}
 
 	/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,14 +26,19 @@ export class Collection<K, V> extends Map<K, V> {
 	public static readonly default: typeof Collection = Collection;
 
 	/**
-	 * Gets an element if the key exists, otherwise sets and returns the provided default value.
-	 * @param {*} key - Key to ensure from the collection.
-	 * @param {function} getDefaultValue - Function that returns the default value to be set and returned if the key doesn't exist.
-	 * @returns {*} The existing value if any, the provided return value otherwise.
+	 * Obtains an element if the key exists, otherwise sets and returns the value provided by the default value generator.
+	 *
+	 * @param {*} key - Key to ensure (if unset) or return from the collection (if set)
+	 * @param {function} defaultValueGenerator - Function that returns a value to be set (if unset) and returned afterwards
+	 *
+	 * @returns The existing value if any, otherwise the value provided by the default value generator.
+	 *
+	 * @example
+	 * collection.ensure(guildId, () => defaultGuildConfig);
 	 */
-	public ensure(key: K, getDefaultValue: () => V): V {
-		if (this.has(key)) return this.get(key)!;
-		const defaultValue = getDefaultValue();
+	public ensure(key: K, defaultValueGenerator: (key: K, collection: this) => V): V | undefined {
+		if (this.has(key)) return this.get(key);
+		const defaultValue = defaultValueGenerator(key, this);
 		this.set(key, defaultValue);
 		return defaultValue;
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,18 @@ export class Collection<K, V> extends Map<K, V> {
 	public static readonly default: typeof Collection = Collection;
 
 	/**
+	 * Gets an element if the key exists, otherwise sets it to {@param defaultValue} and returns the {@param defaultValue}.
+	 * @param {*} key - Key to get from/set to the collection.
+	 * @param {*} defaultValue - Default value to be set and returned if the key doesn't exist.
+	 * @returns {*}
+	 */
+	public ensure(key: K, defaultValue: V): V {
+		if (this.has(key)) return this.get(key)!;
+		this.set(key, defaultValue);
+		return defaultValue;
+	}
+
+	/**
 	 * Checks if all of the elements exist in the collection.
 	 *
 	 * @param keys - The keys of the elements to check for

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export class Collection<K, V> extends Map<K, V> {
 	public static readonly default: typeof Collection = Collection;
 
 	/**
-	 * Gets an element if the key exists, otherwise sets it to {@param defaultValue} and returns the {@param defaultValue}.
+	 * Gets an element if the key exists, otherwise sets and returns {@param defaultValue}.
 	 * @param {*} key - Key to get from/set to the collection.
 	 * @param {*} defaultValue - Default value to be set and returned if the key doesn't exist.
 	 * @returns {*}


### PR DESCRIPTION
**This PR is a continuation of #40 which was closed by the author.**

> Inspired by Enmap#ensure, Collection#ensure gets an element with the specified key if it exists, otherwise sets it to the provided defaultValue and returns the defaultValue. Useful for things like per-guild settings where you want to get it or set it to a default value all in one call.

I found @kxmndz 's PR to be useful and wanted to *ensure* that it was maintained.

**Potential Usage Example:**
```js
const guildConfigs = new Discord.Collection();
const defaultGuildConfig = {
  allowInvitesInChat: true,
};
const guildConfig = guildConfigs.ensure('566340180831633429', () => defaultGuildConfig);
```

**Noticeable deviations from PR #40:**
- The PR builds off of #40 (rebased)
- The expected return value from `collection#ensure` can now be `undefined|null` whereas before a non-nullish return value [was expected](https://github.com/kxmndz/collection/blob/a0efa4077f220cf1df247a87faaaaee4e5dbb902/src/index.ts#L75-L76).
- 2 parameters have been added to the generator function `key: K, collection: this`.  
I believe that recycling these into the generator function will allow for less repetition in the end-user's code.
- @kyranet 's [suggested edit](https://github.com/discordjs/collection/pull/40#discussion_r646333990) was considered but directly interferes with the ability to have `undefined|null` as a valid ensured value, therefore it was not implemented into this PR.

**Tests:**
I'm not good at writing tests and would appreciate if someone help could contribute tests to cover the additional functionality added by this PR compared to the tests carried over by #40.

**Status and versioning classification:**
- Code changes have been tested, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)