### PR TITLE
types: union value types on `intersect` and `difference`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,15 +19,6 @@ export interface Collection<K, V> extends Map<K, V> {
 }
 
 /**
- * A utility type for merging type of collections with two seperate value types.
- *
- * @internal
- */
-export type ValueMerged<K, V, C2 extends Collection<K, unknown>> = C2 extends Collection<K, infer O>
-	? Collection<K, O | V>
-	: never;
-
-/**
  * A Map with additional utility methods. This is used throughout discord.js rather than Arrays for anything that has
  * an ID, for significantly improved performance and ease-of-use.
  */
@@ -638,9 +629,8 @@ export class Collection<K, V> extends Map<K, V> {
 	 *
 	 * @param other The other Collection to filter against
 	 */
-	public intersect<C extends Collection<K, unknown>>(other: C): ValueMerged<K, V, C>;
-	public intersect(other: Collection<K, V>) {
-		const coll = new this.constructor[Symbol.species]<K, V>();
+	public intersect<T>(other: Collection<K, T>): Collection<K, V | T> {
+		const coll = new this.constructor[Symbol.species]<K, V | T>();
 		for (const [k, v] of other) {
 			if (this.has(k)) coll.set(k, v);
 		}
@@ -652,9 +642,8 @@ export class Collection<K, V> extends Map<K, V> {
 	 *
 	 * @param other The other Collection to filter against
 	 */
-	public difference<C extends Collection<K, unknown>>(other: C): ValueMerged<K, V, C>;
-	public difference(other: Collection<K, V>) {
-		const coll = new this.constructor[Symbol.species]<K, V>();
+	public difference<T>(other: Collection<K, T>): Collection<K, V | T> {
+		const coll = new this.constructor[Symbol.species]<K, V | T>();
 		for (const [k, v] of other) {
 			if (!this.has(k)) coll.set(k, v);
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,15 @@ export interface Collection<K, V> extends Map<K, V> {
 }
 
 /**
+ * A utility type for merging type of collections with two seperate value types.
+ *
+ * @internal
+ */
+export type ValueMerged<K, V, C2 extends Collection<K, unknown>> = C2 extends Collection<K, infer O>
+	? Collection<K, O | V>
+	: never;
+
+/**
  * A Map with additional utility methods. This is used throughout discord.js rather than Arrays for anything that has
  * an ID, for significantly improved performance and ease-of-use.
  */
@@ -629,6 +638,7 @@ export class Collection<K, V> extends Map<K, V> {
 	 *
 	 * @param other The other Collection to filter against
 	 */
+	public intersect<C extends Collection<K, unknown>>(other: C): ValueMerged<K, V, C>;
 	public intersect(other: Collection<K, V>) {
 		const coll = new this.constructor[Symbol.species]<K, V>();
 		for (const [k, v] of other) {
@@ -642,6 +652,7 @@ export class Collection<K, V> extends Map<K, V> {
 	 *
 	 * @param other The other Collection to filter against
 	 */
+	public difference<C extends Collection<K, unknown>>(other: C): ValueMerged<K, V, C>;
 	public difference(other: Collection<K, V>) {
 		const coll = new this.constructor[Symbol.species]<K, V>();
 		for (const [k, v] of other) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -629,8 +629,8 @@ export class Collection<K, V> extends Map<K, V> {
 	 *
 	 * @param other The other Collection to filter against
 	 */
-	public intersect<T>(other: Collection<K, T>): Collection<K, V | T> {
-		const coll = new this.constructor[Symbol.species]<K, V | T>();
+	public intersect<T>(other: Collection<K, T>): Collection<K, T> {
+		const coll = new this.constructor[Symbol.species]<K, T>();
 		for (const [k, v] of other) {
 			if (this.has(k)) coll.set(k, v);
 		}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Closes #55

`intersect` and `difference` will provide a collection with a value type that is a union of the collection value type and value type of the collection to run against. Just like before, you need to have a matching key type.

#### For example:
Performing an `intersection` of `Collection<string, string>` onto a `Collection<string, number>` will yield the type `Collection<string, number>`;

Performing an `difference` of `Collection<string, string>` onto a `Collection<string, number>` will yield the type `Collection<string, string | number>`;

Performing an `intersection` or `difference` on a `Collection<string, string>` and a `Collection<number, string>` is an error since key types don't match.

**Status and versioning classification:**
- Code changes have been tested, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
